### PR TITLE
Allow spotWidth or spotHeight to be 0

### DIFF
--- a/main.js
+++ b/main.js
@@ -527,12 +527,8 @@ function updateRobot(robot, callback) {
         adapter.setState(robot.name + '.status.modelName', state.meta.modelName, true);
         adapter.setState(robot.name + '.status.firmware', state.meta.firmware, true);
         adapter.setState(robot.name + '.commands.eco', robot.eco, true);
-        if (robot.spotWidth) {
-            adapter.setState(robot.name + '.commands.spotWidth', robot.spotWidth, true);
-        }
-        if (robot.spotHeight) {
-            adapter.setState(robot.name + '.commands.spotHeight', robot.spotHeight, true);
-        }
+        adapter.setState(robot.name + '.commands.spotWidth', robot.spotWidth, true);
+        adapter.setState(robot.name + '.commands.spotHeight', robot.spotHeight, true);
         adapter.setState(robot.name + '.commands.spotRepeat', robot.spotRepeat, true);
         if (typeof callback === 'function') {
             callback(null);
@@ -643,7 +639,7 @@ function prepareRobotsStructure(robots, devices, callback) {
                                     read: true,
                                     write: true,
                                     def: 100,
-                                    min: 100,
+                                    min: 0,
                                     unit: 'cm',
                                     role: 'level.width'
                                 }
@@ -654,7 +650,7 @@ function prepareRobotsStructure(robots, devices, callback) {
                                     read: true,
                                     write: true,
                                     def: 100,
-                                    min: 100,
+                                    min: 0,
                                     unit: 'cm',
                                     role: 'level.height'
                                 }

--- a/main.js
+++ b/main.js
@@ -527,8 +527,12 @@ function updateRobot(robot, callback) {
         adapter.setState(robot.name + '.status.modelName', state.meta.modelName, true);
         adapter.setState(robot.name + '.status.firmware', state.meta.firmware, true);
         adapter.setState(robot.name + '.commands.eco', robot.eco, true);
-        adapter.setState(robot.name + '.commands.spotWidth', robot.spotWidth, true);
-        adapter.setState(robot.name + '.commands.spotHeight', robot.spotHeight, true);
+        if (robot.spotWidth) {
+            adapter.setState(robot.name + '.commands.spotWidth', robot.spotWidth, true);
+        }
+        if (robot.spotHeight) {
+            adapter.setState(robot.name + '.commands.spotHeight', robot.spotHeight, true);
+        }
         adapter.setState(robot.name + '.commands.spotRepeat', robot.spotRepeat, true);
         if (typeof callback === 'function') {
             callback(null);


### PR DESCRIPTION
It seems that `spotWidth` and `spotHeight` can be 0. The `state` object looks like this in my case:

```json
{
    "version": 1,
    "reqId": "77",
    "result": "ok",
    "data": {},
    "error": null,
    "alert": null,
    "state": 1,
    "action": 0,
    "cleaning": {
        "category": 2,
        "mode": 1,
        "modifier": 1,
        "navigationMode": 1,
        "spotWidth": 0,
        "spotHeight": 0
    },
    "details": {
        "isCharging": false,
        "isDocked": false,
        "isScheduleEnabled": false,
        "dockHasBeenSeen": false,
        "charge": 83
    },
    "availableCommands": {
        "start": true,
        "stop": false,
        "pause": false,
        "resume": false,
        "goToBase": false
    },
    "availableServices": {
        "findMe": "basic-1",
        "generalInfo": "basic-1",
        "houseCleaning": "basic-4",
        "IECTest": "advanced-1",
        "logCopy": "basic-1",
        "manualCleaning": "basic-1",
        "maps": "basic-2",
        "preferences": "basic-2",
        "schedule": "basic-2",
        "softwareUpdate": "basic-1",
        "spotCleaning": "basic-3",
        "wifi": "basic-1"
    },
    "meta": {
        "modelName": "BotVacD7Connected",
        "firmware": "4.5.3-189"
    }
}
```

The ioBroker state `robot.name + '.commands.spotWidth'` must be minimal 100. I see two options:

1) Allow the `spotWidth` to be 0
2) Ignore updates with invalid number for `spotWidth`

This PR simply ignores updates with 0. Let me know what you think.

Fixes #29 